### PR TITLE
Modify the default crontab to actually work.

### DIFF
--- a/Binaries/cronical.dat
+++ b/Binaries/cronical.dat
@@ -56,4 +56,4 @@ SmtpSSL       = false
 # the service under a different user name in Services, or use the psexec utility to impersonate
 # another user. See http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx
 
-@reboot cmd /c echo Hello, world!
+@reboot cmd /c echo Hello, world! I am Cronical. && timeout /t 120

--- a/Cronical/cronical.dat
+++ b/Cronical/cronical.dat
@@ -56,4 +56,4 @@ SmtpSSL       = false
 # the service under a different user name in Services, or use the psexec utility to impersonate
 # another user. See http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx
 
-@reboot cmd /c echo Hello, world!
+@reboot cmd /c echo Hello, world! I am Cronical. && timeout /t 120


### PR DESCRIPTION
Without timeout, the cmd window would close instantly.